### PR TITLE
fixing version comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test: unit-tests test-chrome-ext-upload
 
 unit-tests:
-	mocha
+	./node_modules/.bin/mocha
 
 # Test Chrome extension upload. This requires the passphrase
 # for tests/chrome-extension-keys.js to be exported via the

--- a/src/extension-version.js
+++ b/src/extension-version.js
@@ -23,18 +23,17 @@ function lessThan(versionA, versionB) {
 	var aParts = versionA.split('.');
 	var bParts = versionB.split('.');
 
-	var aHead = aParts[0] || 0;
-	var bHead = bParts[0] || 0;
+	var partsLength = Math.max(aParts.length, bParts.length);
 
-	if (aParts.length == 1 && bParts.length == 1) {
-		return aHead < bHead;
-	} else if (aHead != bHead) {
-		return aHead < bHead;
-	} else {
-		var aTail = aParts.slice(1).join('.');
-		var bTail = bParts.slice(1).join('.');
-		return aHead < bHead || lessThan(aTail, bTail);
+	for(var x = 0; x < partsLength; x++) {
+		var aVal = isNaN(aParts[x]) ? 0 : +aParts[x];
+		var bVal = isNaN(bParts[x]) ? 0 : +bParts[x];
+		if (aVal !== bVal) {
+			return aVal < bVal;
+		}
 	}
+	// if we reached the end of the loop the 2 version are equals
+	return false;
 }
 
 function increment(version, componentIndex) {

--- a/test/extension-version.js
+++ b/test/extension-version.js
@@ -7,11 +7,16 @@ describe('extension-version', function() {
 		expect(extensionVersion.lessThan('1.0', '2.0')).to.equal(true);
 		expect(extensionVersion.lessThan('1.0', '1.0')).to.equal(false);
 		expect(extensionVersion.lessThan('1.0', '0.1')).to.equal(false);
-		
+
+
 		expect(extensionVersion.lessThan('1.0', '1')).to.equal(false);
 		expect(extensionVersion.lessThan('1.0', '1.0.1')).to.equal(true);
+
+		expect(extensionVersion.lessThan('1.0.9', '1.0.10')).to.equal(true);
+		expect(extensionVersion.lessThan('1.0.10', '1.0.99')).to.equal(true);
+		expect(extensionVersion.lessThan('10', '9')).to.equal(false);
 	});
-	
+
 	it('should increment versions', function() {
 		expect(extensionVersion.increment('1.0.1', 0)).to.equal('2.0.1');
 		expect(extensionVersion.increment('1.0.1', 2)).to.equal('1.0.2');


### PR DESCRIPTION
this commits fix an issue in the version comparison that caused version '0.0.9' to be identified as greater than '0.0.10'

This happened because the code was using string comparison when comparing two version pieces and "9" > "10".
I also rewrote the function to be non recursive as splitting and recombining the version wasn't very useful.
